### PR TITLE
Automate gremlin secret keys injection for newly created EC2 servers

### DIFF
--- a/network_and_server.yml
+++ b/network_and_server.yml
@@ -185,9 +185,8 @@ Resources:
                     docker run -l service=nginx --name nginx-app -p 80:80 -d -v /app/:/usr/share/nginx/html nginx
                     # Install Gremlin
                     echo "deb https://deb.gremlin.com/ release non-free" | sudo tee /etc/apt/sources.list.d/gremlin.list
-                    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C81FC2F43A48B25808F9583BDFF170F324D41134 \
-                    9CDB294B29A5B1E2E00C24C022E8EF3461A50EF6
-                    sudo apt-get install -y gremlin gremlind
+                    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C81FC2F43A48B25808F9583BDFF170F324D41134 9CDB294B29A5B1E2E00C24C022E8EF3461A50EF6
+                    sudo apt-get update && sudo apt-get install -y gremlin gremlind
                     # Install Python and awscli
                     sudo apt-get install -y python2.7
                     curl -O https://bootstrap.pypa.io/get-pip.py

--- a/network_and_server.yml
+++ b/network_and_server.yml
@@ -169,8 +169,11 @@ Resources:
                     ca-certificates \
                     curl \
                     gnupg-agent \
-                    software-properties-common \
-                    awscli
+                    software-properties-common
+                    sudo apt-get install -y python2.7
+                    curl -O https://bootstrap.pypa.io/get-pip.py
+                    sudo python2.7 get-pip.py
+                    sudo pip install awscli
                     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
                     add-apt-repository \
                     "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
@@ -187,11 +190,6 @@ Resources:
                     echo "deb https://deb.gremlin.com/ release non-free" | sudo tee /etc/apt/sources.list.d/gremlin.list
                     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C81FC2F43A48B25808F9583BDFF170F324D41134 9CDB294B29A5B1E2E00C24C022E8EF3461A50EF6
                     sudo apt-get update && sudo apt-get install -y gremlin gremlind
-                    # Install Python and awscli
-                    sudo apt-get install -y python2.7
-                    curl -O https://bootstrap.pypa.io/get-pip.py
-                    sudo python2.7 get-pip.py
-                    sudo pip install awscli
                     # Install jq
                     sudo apt-get -y install jq
                     # Configuring Gremlin Daemon
@@ -199,10 +197,8 @@ Resources:
                     sudo chmod 777 /etc/default/gremlind
                     echo 'GREMLIN_TEAM_CERTIFICATE_OR_FILE="file:///var/lib/gremlin/gremlin.pub_cert.pem"' >> /etc/default/gremlind
                     echo 'GREMLIN_TEAM_PRIVATE_KEY_OR_FILE="file:///var/lib/gremlin/gremlin.priv_key.pem"' >> /etc/default/gremlind
-                    export GREMLIN_TEAM_ID=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[35:71]'' | tr -d '"')
-                    export GREMLIN_TEAM_SECRET=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[100:136]'' | tr -d '"')
-                    echo 'GREMLIN_TEAM_ID='$GREMLIN_TEAM_ID'' >> /etc/default/gremlind
-                    echo 'GREMLIN_TEAM_SECRET='$GREMLIN_TEAM_SECRET'' >> /etc/default/gremlind
+                    echo  GREMLIN_TEAM_ID=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[35:71]'' | tr -d '\"') >> /etc/default/gremlind
+                    echo  GREMLIN_TEAM_SECRET=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[100:136]'' | tr -d '\"') >> /etc/default/gremlind
                     sudo systemctl reload gremlind
             ImageId: ami-052ae783527d1a0c9
             KeyName: platforms-key

--- a/network_and_server.yml
+++ b/network_and_server.yml
@@ -200,10 +200,8 @@ Resources:
                     sudo chmod 777 /etc/default/gremlind
                     echo 'GREMLIN_TEAM_CERTIFICATE_OR_FILE="file:///var/lib/gremlin/gremlin.pub_cert.pem"' >> /etc/default/gremlind
                     echo 'GREMLIN_TEAM_PRIVATE_KEY_OR_FILE="file:///var/lib/gremlin/gremlin.priv_key.pem"' >> /etc/default/gremlind
-                    export GREMLIN_TEAM_ID=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | \
-                    jq ' {secrets: .SecretString} | tostring | '.[35:71]'' | tr -d '"')
-                    export GREMLIN_TEAM_SECRET=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | \
-                    jq ' {secrets: .SecretString} | tostring | '.[100:136]'' | tr -d '"')
+                    export GREMLIN_TEAM_ID=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[35:71]'' | tr -d '"')
+                    export GREMLIN_TEAM_SECRET=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | jq ' {secrets: .SecretString} | tostring | '.[100:136]'' | tr -d '"')
                     echo 'GREMLIN_TEAM_ID='$GREMLIN_TEAM_ID'' >> /etc/default/gremlind
                     echo 'GREMLIN_TEAM_SECRET='$GREMLIN_TEAM_SECRET'' >> /etc/default/gremlind
                     sudo systemctl reload gremlind

--- a/network_and_server.yml
+++ b/network_and_server.yml
@@ -183,6 +183,30 @@ Resources:
                     chmod 777 -R /app/
                     aws s3 cp s3://c3pipelines-devops /app/ --recursive
                     docker run -l service=nginx --name nginx-app -p 80:80 -d -v /app/:/usr/share/nginx/html nginx
+                    # Install Gremlin
+                    echo "deb https://deb.gremlin.com/ release non-free" | sudo tee /etc/apt/sources.list.d/gremlin.list
+                    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C81FC2F43A48B25808F9583BDFF170F324D41134 \
+                    9CDB294B29A5B1E2E00C24C022E8EF3461A50EF6
+                    sudo apt-get install -y gremlin gremlind
+                    # Install Python and awscli
+                    sudo apt-get install -y python2.7
+                    curl -O https://bootstrap.pypa.io/get-pip.py
+                    sudo python2.7 get-pip.py
+                    sudo pip install awscli
+                    # Install jq
+                    sudo apt-get -y install jq
+                    # Configuring Gremlin Daemon
+                    sudo mv /etc/default/gremlind.example /etc/default/gremlind
+                    sudo chmod 777 /etc/default/gremlind
+                    echo 'GREMLIN_TEAM_CERTIFICATE_OR_FILE="file:///var/lib/gremlin/gremlin.pub_cert.pem"' >> /etc/default/gremlind
+                    echo 'GREMLIN_TEAM_PRIVATE_KEY_OR_FILE="file:///var/lib/gremlin/gremlin.priv_key.pem"' >> /etc/default/gremlind
+                    export GREMLIN_TEAM_ID=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | \
+                    jq ' {secrets: .SecretString} | tostring | '.[35:71]'' | tr -d '"')
+                    export GREMLIN_TEAM_SECRET=$(aws secretsmanager get-secret-value --secret-id xconf/gremlin --region us-west-1 --output json | \
+                    jq ' {secrets: .SecretString} | tostring | '.[100:136]'' | tr -d '"')
+                    echo 'GREMLIN_TEAM_ID='$GREMLIN_TEAM_ID'' >> /etc/default/gremlind
+                    echo 'GREMLIN_TEAM_SECRET='$GREMLIN_TEAM_SECRET'' >> /etc/default/gremlind
+                    sudo systemctl reload gremlind
             ImageId: ami-052ae783527d1a0c9
             KeyName: platforms-key
             AssociatePublicIpAddress: true


### PR DESCRIPTION
There was an issue when running Gremlin attacks over the active EC2 servers, after the attack is over the number of servers goes back to the original number (2) but the instances that at first had the Gremlin Secret Keys are in **terminated** state and we have fresh news instances in **active** state (these instances don't have the keys because the process is manual).
I automated the secrets retrieving, using AWS Secrets Manager.